### PR TITLE
Fix #5 and #7: Update cmdparser.hpp to fix a few issues

### DIFF
--- a/cmdparser.hpp
+++ b/cmdparser.hpp
@@ -1,6 +1,6 @@
 /*
-	This file is part of the C++ CmdParser utility.
-	Copyright (c) 2015 - 2016 Florian Rappl
+  This file is part of the C++ CmdParser utility.
+  Copyright (c) 2015 - 2016 Florian Rappl
 */
 
 #pragma once
@@ -428,16 +428,16 @@ namespace cli {
 			ss << "Available parameters:\n\n";
 
 			for (const auto& command : _commands) {
-				ss << "	 " << command->command << "\t" << command->alternative;
+				ss << "  " << command->command << "\t" << command->alternative;
 
 				if (command->required == true) {
 					ss << "\t(required)";
 				}
 
-				ss << "\n		" << command->description;
+				ss << "\n   " << command->description;
 
 				if (command->required == false) {
-					ss << "\n		" << "This parameter is optional. The default value is '" + command->print_value() << "'.";
+					ss << "\n   " << "This parameter is optional. The default value is '" + command->print_value() << "'.";
 				}
 
 				ss << "\n\n";
@@ -447,7 +447,7 @@ namespace cli {
 		}
 
 		void print_help(std::stringstream& ss) const {
-			if (has_help())	 {
+			if (has_help()) {
 				ss << "For more help use --help or -h.\n";
 			}
 		}


### PR DESCRIPTION
Update cmdparser.hpp to fix:

1. Properly parsing ``std::vector<std::string>`` (crashed due to default initializing a ``std::vector<>`` to 0)
2. Ensuring the default argument consumes leftover variadic arguments at the beginning, middle, and end of the line
3. Ensuring that dominant arguments (like help) will appear even if required arguments are missing