### PR TITLE
Parse numbers from decimal, octal and hexadecimal number systems.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Let's look at an example:
 ```cpp
 void configure_parser(cli::Parser& parser) {
 	parser.set_optional<std::string>("o", "output", "data", "Strings are naturally included.");
-	parser.set_optional<int>("n", "number", 8, "Integers in all forms, e.g., unsigned int, long long, ..., are possible.");
+	parser.set_optional<int>("n", "number", 8, "Integers in all forms, e.g., unsigned int, long long, ..., are possible. Hexadecimal and Ocatl numbers parsed as well");
+	parser.set_optional<cli::NumericalBase<int, 10>>("t", "temp", 0, "integer parsing restricted only to numerical base 10");
 	parser.set_optional<double>("b", "beta", 11.0, "Also floating point values are possible.");
 	parser.set_optional<bool>("a", "all", false, "Boolean arguments are simply switched when encountered, i.e. false to true if provided.");
 	parser.set_required<std::vector<short>>("v", "values", "By using a vector it is possible to receive a multitude of inputs.");
@@ -51,6 +52,9 @@ Getting values is possible via the `get` method. This is also a template. We nee
 ```cpp
 //auto will be int
 auto number = parser.get<int>("n");
+
+//auto will be int, note specification of numerical base same as when set during parser configuration
+auto number = parser.get<cli::NumericalBase<int, 10> >("t");
 
 //auto will be std::string
 auto output = parser.get<std::string>("o");

--- a/cmdparser.hpp
+++ b/cmdparser.hpp
@@ -12,6 +12,28 @@
 #include <functional>
 
 namespace cli {
+	/// Class used to wrap integer types to specify desired numerical base for specific argument parsing
+	template <typename T, int numericalBase = 0> class NumericalBase {
+	public:
+
+		/// This constructor required for correct AgrumentCountChecker initialization
+		NumericalBase() : value(0), base(numericalBase) {}
+
+		/// This constructor required for default value initialization
+		/// \param val comes from default value
+		NumericalBase(T val) : value(val), base(numericalBase) {}
+
+		operator T () const {
+			return this->value;
+		}
+		operator T * () {
+			return this->value;
+		}
+
+		T             value;
+		unsigned  int base;
+	};
+
 	struct CallbackArgs {
 		const std::vector<std::string>& arguments;
 		std::ostream& output;
@@ -56,6 +78,12 @@ namespace cli {
 
 		template<typename T>
 		struct ArgumentCountChecker
+		{
+			static constexpr bool Variadic = false;
+		};
+
+		template<typename T>
+		struct ArgumentCountChecker<cli::NumericalBase<T>>
 		{
 			static constexpr bool Variadic = false;
 		};
@@ -114,11 +142,11 @@ namespace cli {
 			T value;
 		};
 
-		static int parse(const std::vector<std::string>& elements, const int&) {
+		static int parse(const std::vector<std::string>& elements, const int&, int numberBase = 0) {
 			if (elements.size() != 1)
 				throw std::bad_cast();
 
-			return std::stoi(elements[0]);
+			return std::stoi(elements[0], 0, numberBase);
 		}
 
 		static bool parse(const std::vector<std::string>& elements, const bool& defval) {
@@ -149,18 +177,18 @@ namespace cli {
 			return std::stold(elements[0]);
 		}
 
-		static unsigned int parse(const std::vector<std::string>& elements, const unsigned int&) {
+		static unsigned int parse(const std::vector<std::string>& elements, const unsigned int&, int numberBase = 0) {
 			if (elements.size() != 1)
 				throw std::bad_cast();
 
-			return static_cast<unsigned int>(std::stoul(elements[0]));
+			return static_cast<unsigned int>(std::stoul(elements[0], 0, numberBase));
 		}
 
-		static unsigned long parse(const std::vector<std::string>& elements, const unsigned long&) {
+		static unsigned long parse(const std::vector<std::string>& elements, const unsigned long&, int numberBase = 0) {
 			if (elements.size() != 1)
 				throw std::bad_cast();
 
-			return std::stoul(elements[0]);
+			return std::stoul(elements[0], 0, numberBase);
 		}
 
 		static long parse(const std::vector<std::string>& elements, const long&) {
@@ -191,9 +219,28 @@ namespace cli {
 			return values;
 		}
 
+		template <typename T> static T parse(const std::vector<std::string>& elements, const NumericalBase<T>& wrapper) {
+			return parse(elements, wrapper.value, 0);
+		}
+
+		/// Specialization for number wrapped into numerical base
+		/// \tparam T base type of the argument
+		/// \tparam base numerical base
+		/// \param elements
+		/// \param wrapper
+		/// \return parsed number
+		template <typename T, int base> static T parse(const std::vector<std::string>& elements, const NumericalBase<T, base>& wrapper) {
+			return parse(elements, wrapper.value, wrapper.base);
+		}
+
 		template<class T>
 		static std::string stringify(const T& value) {
 			return std::to_string(value);
+		}
+
+		template<class T, int base>
+		static std::string stringify(const NumericalBase<T, base>& wrapper) {
+			return std::to_string(wrapper.value);
 		}
 
 		template<class T>


### PR DESCRIPTION
By default accepting all supported numerical systems. For specific arguments numerical system can be specified explicitly with additional wrapper class "NumericalBase. See README.md