### PR TITLE
Add parse() method for unsigned long long

### DIFF
--- a/cmdparser.hpp
+++ b/cmdparser.hpp
@@ -191,11 +191,18 @@ namespace cli {
 			return std::stoul(elements[0], 0, numberBase);
 		}
 
-		static long parse(const std::vector<std::string>& elements, const long&) {
+		static unsigned long long parse(const std::vector<std::string>& elements, const unsigned long long&, int numberBase = 0) {
 			if (elements.size() != 1)
 				throw std::bad_cast();
 
-			return std::stol(elements[0]);
+			return std::stoull(elements[0], 0, numberBase);
+		}
+
+		static long parse(const std::vector<std::string>& elements, const long&, int numberBase = 0) {
+			if (elements.size() != 1)
+				throw std::bad_cast();
+
+			return std::stol(elements[0], 0, numberBase);
 		}
 
 		static std::string parse(const std::vector<std::string>& elements, const std::string&) {


### PR DESCRIPTION
[Reason]
error: call to 'parse' is ambiguous while trying instantiate parser.set_optional<size_t>(...).

Occurred on Win64, where size_t might be treated as unsigned long long.

[Misc]
Add numberBase to parse() method signature for long.