### PR TITLE
Change to support nested cmd options based on top level commands

### DIFF
--- a/cmdparser.hpp
+++ b/cmdparser.hpp
@@ -357,6 +357,24 @@ namespace cli {
 			return run(output, std::cerr);
 		}
 
+		bool doesArgumentExist(std::string name, std::string altName)
+		{
+			for (const auto argument : _arguments) {
+				
+				if(argument == '-'+ name || argument == altName)
+				{
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		inline bool doesHelpExist()
+		{
+			return doesArgumentExist("h", "--help");
+		}
+
 		bool run(std::ostream& output, std::ostream& error) {
 			if (_arguments.size() > 0) {
 				auto current = find_default();


### PR DESCRIPTION
I first made this change Tue Oct 31 17:11:24 2017 -0400. And just now realized I never tried to upstreamed this. I've found this really useful and if possible would like to upstream. This is an example of my use case from them:
```
class AutoCLI
{
private:
	std::unique_ptr<BaseCLIParser> CliParser;
	void initParser(int argc, char** argv)
	{
		cli::Parser parser(argc, argv);
	
		if (parser.doesArgumentExist(DecryptCLIParser::name, "--" + DecryptCLIParser::altName))
		{
			CliParser = std::unique_ptr<BaseCLIParser>(new DecryptCLIParser(argc, argv));
			return;
		}

		if (parser.doesArgumentExist(EncryptCLIParser::name, "--" + EncryptCLIParser::altName))
		{
			CliParser = std::unique_ptr<BaseCLIParser>(new EncryptedDataMarkingsCLIParser(argc, argv));
			return;
		}
	}
public:
	AutoCLI(int argc, char** argv)
	{
		initParser(argc, argv);
		
		if (CliParser)
		{
			CliParser->executeAction();
		}
	}
};
```
essentially I wanted a light\simple way to check the arguments lists before deciding which parser to invoke.