### PR TITLE
disable unreachable code  warning for msvc.

### DIFF
--- a/cmdparser.hpp
+++ b/cmdparser.hpp
@@ -303,8 +303,11 @@ namespace cli {
 		void enable_help() {
 			set_callback("h", "help", std::function<bool(CallbackArgs&)>([this](CallbackArgs& args){
 				args.output << this->usage();
+				#pragma warning(push)
+				#pragma warning(disable: 4702)
 				exit(0);
 				return false;
+				#pragma warning(pop)
 			}), "", true);
 		}
 


### PR DESCRIPTION
This will reduce build log pollution.  like this

```
D:\a\Disassembler\Disassembler\packages\cmdParser\cmdparser.hpp(307): warning C4702: unreachable code [D:\a\Disassembler\Disassembler\build\src\cli\disasm.vcxproj]
D:\a\Disassembler\Disassembler\packages\cmdParser\cmdparser.hpp(307): warning C4702: unreachable code [D:\a\Disassembler\Disassembler\build\src\cli\disasm.vcxproj]
D:\a\Disassembler\Disassembler\packages\cmdParser\cmdparser.hpp(307): warning C4702: unreachable code [D:\a\Disassembler\Disassembler\build\src\cli\disasm.vcxproj]
D:\a\Disassembler\Disassembler\packages\cmdParser\cmdparser.hpp(307): warning C4702: unreachable code [D:\a\Disassembler\Disassembler\build\src\cli\disasm.vcxproj]
D:\a\Disassembler\Disassembler\packages\cmdParser\cmdparser.hpp(307): warning C4702: unreachable code [D:\a\Disassembler\Disassembler\build\src\cli\disasm.vcxproj]
D:\a\Disassembler\Disassembler\packages\cmdParser\cmdparser.hpp(307): warning C4702: unreachable code [D:\a\Disassembler\Disassembler\build\src\cli\disasm.vcxproj]
```