### PR TITLE
Support long long type for IA32 architecture

### DIFF
--- a/cmdparser.hpp
+++ b/cmdparser.hpp
@@ -198,6 +198,13 @@ namespace cli {
 			return std::stoull(elements[0], 0, numberBase);
 		}
 
+		static long long parse(const std::vector<std::string>& elements, const long long&, int numberBase = 0) {
+			if (elements.size() != 1)
+				throw std::bad_cast();
+
+			return std::stoll(elements[0], 0, numberBase);
+		}
+
 		static long parse(const std::vector<std::string>& elements, const long&, int numberBase = 0) {
 			if (elements.size() != 1)
 				throw std::bad_cast();


### PR DESCRIPTION
`Long long` type was not supported in this library due to 64-bit does not consider as a problem, defined as `int `already. 

However, when we tried to use this library for IA32 architecture, `int64_t `type was not compiled due to the same problem. Because int64_t was handled as `long long ` in IA32 architecture which was not implemented in the library. 

Could you please check this implementation and leave a comment about the fix?

