### PR TITLE
Fix memory leak in disable_help

### DIFF
--- a/cmdparser.hpp
+++ b/cmdparser.hpp
@@ -352,6 +352,7 @@ namespace cli {
 			for (auto command = _commands.begin(); command != _commands.end(); ++command) {
 				if ((*command)->name == "h" && (*command)->alternative == "--help") {
 					_commands.erase(command);
+					delete *command;
 					break;
 				}
 			}


### PR DESCRIPTION
Reference: #32
I just noticed that this issue has been ongoing for a long time but no one made a pull request yet. 

## [Before] Valgrind detects "definitely lost" 
Run with `parser.disable_help()`.
```
==225494== LEAK SUMMARY:
==225494==    definitely lost: 216 bytes in 1 blocks
==225494==    indirectly lost: 0 bytes in 0 blocks
==225494==      possibly lost: 0 bytes in 0 blocks
==225494==    still reachable: 0 bytes in 0 blocks
==225494==         suppressed: 0 bytes in 0 blocks
```